### PR TITLE
Fix landmark scaling using original image size

### DIFF
--- a/dataset.py
+++ b/dataset.py
@@ -5,34 +5,47 @@ from torch.utils.data import Dataset
 import torch
 
 class LandmarkDataset(Dataset):
+    """Dataset returning landmark coordinates in pixel space and image size."""
+
     def __init__(self, root_dir, csv_file="landmark_summary.csv", transform=None):
         self.root_dir = root_dir
         self.transform = transform
         self.data = pd.read_csv(os.path.join(root_dir, csv_file))
-        # Determine list of all landmark labels
+
+        # Determine the full list of labels present in the CSV
         self.labels = sorted(self.data["PointLabel"].unique())
         self.label_to_idx = {l: i for i, l in enumerate(self.labels)}
-        # Organize coordinates per sample
+
+        # Pre-process all samples so that original image size is known
         self.samples = []
         for sample_id, group in self.data.groupby("SampleID"):
             img_path = os.path.join(root_dir, str(sample_id), f"xray{sample_id}.jpg")
-            coords = torch.zeros(len(self.labels), 2, dtype=torch.float32)
+            coords_px = torch.zeros(len(self.labels), 2, dtype=torch.float32)
             mask = torch.zeros(len(self.labels), dtype=torch.float32)
-            # open image once to know width/height
+
+            # Obtain original image width/height once
             if os.path.exists(img_path):
                 w, h = Image.open(img_path).size
             else:
                 w = h = 1.0
+
             for _, row in group.iterrows():
                 label = row["PointLabel"]
                 if label not in self.label_to_idx:
                     continue
                 idx = self.label_to_idx[label]
-                x = row["X"] / w
-                y = row["Y"] / h
-                coords[idx] = torch.tensor([x, y])
+                x = row["X"]
+                y = row["Y"]
+                coords_px[idx] = torch.tensor([x, y])
                 mask[idx] = 1.0
-            self.samples.append({"image_path": img_path, "coords": coords, "mask": mask})
+
+            self.samples.append({
+                "image_path": img_path,
+                "coords_px": coords_px,
+                "mask": mask,
+                "width": torch.tensor(w, dtype=torch.float32),
+                "height": torch.tensor(h, dtype=torch.float32),
+            })
 
     def __len__(self):
         return len(self.samples)
@@ -42,4 +55,10 @@ class LandmarkDataset(Dataset):
         img = Image.open(sample["image_path"]).convert("RGB")
         if self.transform:
             img = self.transform(img)
-        return img, sample["coords"], sample["mask"]
+        return (
+            img,
+            sample["coords_px"],
+            sample["mask"],
+            sample["width"],
+            sample["height"],
+        )


### PR DESCRIPTION
## Summary
- store landmark pixel coordinates and image size in `LandmarkDataset`
- normalize landmarks in `train.py` based on original size
- rescale dataset coordinates inside `predict.py`
- allow exporting predicted coordinates to CSV
- save trained model after training

## Testing
- `python train.py --epochs 1 --batch-size 2`
- `python predict.py 1/xray1.jpg --model model.pth --output-csv preds.csv --no-match`

------
https://chatgpt.com/codex/tasks/task_e_6886997011b08324b4a5cfa408f0c275